### PR TITLE
Add compile-time check for which filesystem library header to include

### DIFF
--- a/src/CrawlDirectory.hpp
+++ b/src/CrawlDirectory.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "Utils/HashString.hpp"
+#include "Filesystem.hpp"
 
-#include <filesystem>
 #include <regex>
 #include <vector>
 #include <iostream>
@@ -10,8 +10,7 @@
 namespace tsm::utils {
 
 ///
-auto crawlDirectory(const std::filesystem::path& inputDirOrIndexFile, const std::string& regex, const std::string& engine) {
-    namespace fs = ::std::filesystem;
+auto crawlDirectory(const fs::path& inputDirOrIndexFile, const std::string& regex, const std::string& engine) {
     using recursive_dir_iterator = fs::recursive_directory_iterator;
 
     std::vector<fs::path> paths;

--- a/src/DataFileDesc.hpp
+++ b/src/DataFileDesc.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "TypeTimestamp.hpp"
+#include "Filesystem.hpp"
 
 #include "VariableDesc.hpp"
 
-#include <filesystem>
 
 namespace tsm::ds {
 
@@ -12,7 +12,7 @@ struct [[nodiscard]] DataFileDesc {
     ///
     DataFileDesc() noexcept = default;
     ///
-    DataFileDesc(const std::vector<timestamp_t>& timestamps, const std::vector<VariableDesc>& variables, const std::filesystem::path& path) :  Timestamps{timestamps},
+    DataFileDesc(const std::vector<timestamp_t>& timestamps, const std::vector<VariableDesc>& variables, const fs::path& path) :  Timestamps{timestamps},
                                                                                                                                             Variables{variables},
                                                                                                                                             NCFilePath{path} {}
 
@@ -32,7 +32,7 @@ struct [[nodiscard]] DataFileDesc {
 
     const std::vector<timestamp_t> Timestamps;
     const std::vector<VariableDesc> Variables;
-    const std::filesystem::path NCFilePath;
+    const fs::path NCFilePath;
 };
 
 } // namespace tsm

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -8,8 +8,6 @@
 #include <iostream>
 #include <unordered_set>
 
-namespace fs = std::filesystem;
-
 // Required queries:
 // SELECT filepath FROM Timestamps INNER JOIN Filepaths WHERE timestamp='2193091200';
 
@@ -28,7 +26,7 @@ auto toString(const T numeric) {
 }
 
 /***********************************************************************************/
-Database::Database(const std::filesystem::path& outputPath, const std::string& datasetName) :
+Database::Database(const fs::path& outputPath, const std::string& datasetName) :
                                                                                                                                     m_outputFilePath{ outputPath / (datasetName + ".sqlite3")} {
 
     configureSQLITE();

--- a/src/Database.hpp
+++ b/src/Database.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "Utils/DeletedUniquePtr.hpp"
+#include "Filesystem.hpp"
 #include "VariableDesc.hpp"
 
 #include <string>
 #include <unordered_set>
-#include <filesystem>
 
 // Forward declarations
 struct sqlite3;
@@ -21,7 +21,7 @@ class Database {
 
 public:
 
-    Database(const std::filesystem::path& outputPath, const std::string& datasetName);
+    Database(const fs::path& outputPath, const std::string& datasetName);
     ~Database();
 
     /// Opens database.
@@ -60,7 +60,7 @@ private:
     void printErrorMsg();
 
     sqlite3* m_DBHandle{ nullptr };
-    const std::filesystem::path m_outputFilePath;
+    const fs::path m_outputFilePath;
 };
 
 } // namespace tsm

--- a/src/DatasetDesc.cpp
+++ b/src/DatasetDesc.cpp
@@ -6,7 +6,7 @@
 namespace tsm::ds {
 
 /***********************************************************************************/
-DatasetDesc::DatasetDesc(const std::vector<std::filesystem::path>& filePaths, const DATASET_TYPE type) : m_datasetType{ type } {
+DatasetDesc::DatasetDesc(const std::vector<fs::path>& filePaths, const DATASET_TYPE type) : m_datasetType{ type } {
     m_ncFiles.reserve(filePaths.size());
 
     tsm::utils::ProgressBar pb{ filePaths.size() };

--- a/src/DatasetDesc.hpp
+++ b/src/DatasetDesc.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Filesystem.hpp"
 #include "DataFileDesc.hpp"
 
 #include <ncFile.h>
@@ -7,7 +8,6 @@
 //#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <vector>
-#include <filesystem>
 
 namespace tsm {
 class Database;
@@ -26,7 +26,7 @@ friend class ::tsm::Database;
 
 public:
     ///
-    DatasetDesc(const std::vector<std::filesystem::path>& filePaths, const DATASET_TYPE type);
+    DatasetDesc(const std::vector<fs::path>& filePaths, const DATASET_TYPE type);
 
     explicit operator bool() const noexcept {
         return !m_ncFiles.empty();

--- a/src/FileReaders/Grib2FileReader.cpp
+++ b/src/FileReaders/Grib2FileReader.cpp
@@ -2,6 +2,6 @@
 
 namespace tsm {
 
-Grib2FileReader::Grib2FileReader(const std::filesystem::path& path) : m_path{ path } {}
+Grib2FileReader::Grib2FileReader(const fs::path& path) : m_path{ path } {}
 
 } // namespace tsm

--- a/src/FileReaders/Grib2FileReader.hpp
+++ b/src/FileReaders/Grib2FileReader.hpp
@@ -2,22 +2,21 @@
 
 #error GRIB2 reader not implemented.
 
+#include "../Filesystem.hpp"
 #include "FileReader.hpp"
-
-#include <filesystem>
 
 namespace tsm {
 
 class Grib2FileReader : public FileReader<Grib2FileReader> {
 
 public:
-    explicit Grib2FileReader(const std::filesystem::path& path);
+    explicit Grib2FileReader(const fs::path& path);
 
     ///
     [[nodiscard]] ds::DataFileDesc getDataFileDesc_impl();
 
 private:
-    const std::filesystem::path m_path;
+    const fs::path m_path;
 };
 
 } // namespace tsm

--- a/src/FileReaders/NCFileReader.cpp
+++ b/src/FileReaders/NCFileReader.cpp
@@ -8,7 +8,7 @@
 namespace tsm {
     
 /***********************************************************************************/
-NCFileReader::NCFileReader(const std::filesystem::path& path) : m_path{path} {}
+NCFileReader::NCFileReader(const fs::path& path) : m_path{path} {}
 
 /***********************************************************************************/
 ds::DataFileDesc NCFileReader::getDataFileDesc_impl() {

--- a/src/FileReaders/NCFileReader.hpp
+++ b/src/FileReaders/NCFileReader.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "../Filesystem.hpp"
 #include "FileReader.hpp"
 
 #include "../VariableDesc.hpp"
 
-#include <filesystem>
 #include <iostream>
 
 #include <ncFile.h>
@@ -15,7 +15,7 @@ class NCFileReader : public FileReader<NCFileReader> {
 
 public:
     ///
-    explicit NCFileReader(const std::filesystem::path& path);
+    explicit NCFileReader(const fs::path& path);
     ///
     ~NCFileReader() {
         m_file.close();
@@ -34,7 +34,7 @@ private:
     ///
     [[nodiscard]] std::vector<ds::timestamp_t> getTimestampValues() const;
 
-    const std::filesystem::path m_path;
+    const fs::path m_path;
     netCDF::NcFile m_file;
 };
 

--- a/src/Filesystem.hpp
+++ b/src/Filesystem.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+// Compatibility wrapper for older versions of GCC (5-7)
+// which don't fully implement the filesystem library.
+
+#ifdef __has_include
+    #if __has_include(<filesystem>)
+        #include <filesystem>
+
+        namespace fs = ::std::filesystem;
+    #else
+        #include <experimental/filesystem>
+
+        namespace fs = ::std::experimental::filesystem;
+    #endif
+#endif

--- a/src/TimestampMapper.cpp
+++ b/src/TimestampMapper.cpp
@@ -8,8 +8,6 @@
 #include <fstream>
 #include <regex>
 
-namespace fs = std::filesystem;
-
 namespace tsm {
 
 /***********************************************************************************/
@@ -83,7 +81,7 @@ bool TimestampMapper::exec() {
 }
 
 /***********************************************************************************/
-bool TimestampMapper::createDirectory(const std::filesystem::path& path) const noexcept {
+bool TimestampMapper::createDirectory(const fs::path& path) const noexcept {
     std::error_code e;
     fs::create_directory(path, e);
 
@@ -95,7 +93,7 @@ bool TimestampMapper::createDirectory(const std::filesystem::path& path) const n
 }
 
 /***********************************************************************************/
-std::vector<fs::path> TimestampMapper::createFileList(const std::filesystem::path& inputDirOrIndexFile, const std::string& regex, const std::string& engine) const {
+std::vector<fs::path> TimestampMapper::createFileList(const fs::path& inputDirOrIndexFile, const std::string& regex, const std::string& engine) const {
 
     // If file_to_index.txt exists, pull the file paths from there.
     const std::unordered_set<std::string> exts{ ".txt", ".diff", ".lst" };

--- a/src/TimestampMapper.hpp
+++ b/src/TimestampMapper.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <filesystem>
+#include "Filesystem.hpp"
+
 #include <algorithm>
 #include <cctype>
 
@@ -30,14 +31,14 @@ private:
         return res;
     }
     ///
-    [[nodiscard]] inline auto fileOrDirExists(const std::filesystem::path& path) const {
-        return std::filesystem::exists(path);
+    [[nodiscard]] inline auto fileOrDirExists(const fs::path& path) const {
+        return fs::exists(path);
     }
     ///
-    [[nodiscard]] bool createDirectory(const std::filesystem::path& path) const noexcept;
+    [[nodiscard]] bool createDirectory(const fs::path& path) const noexcept;
     ///
-    [[nodiscard]] std::vector<std::filesystem::path> 
-                                        createFileList(const std::filesystem::path& inputDirOrIndexFile, const std::string& regex, const std::string& engine) const;
+    [[nodiscard]] std::vector<fs::path> 
+                                        createFileList(const fs::path& inputDirOrIndexFile, const std::string& regex, const std::string& engine) const;
     ///
     [[nodiscard]] inline auto shouldDeleteIndexFile() const noexcept {
         return m_indexFileExists && !m_cliOptions.KeepIndexFile;


### PR DESCRIPTION
This will allow older GCC versions < 8 to compile this...*cough* GPSC *cough*.

Compiles fine on GCC 9 and tests pass. No guarantee with older GCC versions yet.