### PR TITLE
Fix typo in Makefile && add OpenSSL to conda env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
-lib_dir := $(CONDA_PREFIX)/lib
-include_dir := $(CONDA_PREFIX)/include
+lib_dir := ${CONDA_PREFIX}/lib
+include_dir := ${CONDA_PREFIX}/include
 
 compiler_and_flags := $(CXX) -std=c++17 -Wall -Wextra -Wno-unused-variable -march=native -O3 -pedantic -Wshadow -I$(include_dir) -Wl,-rpath=$(lib_dir) -L$(lib_dir)
 
@@ -8,7 +8,7 @@ shared_cpp_files := src/TimestampMapper.cpp src/Utils/ProgressBar.cpp src/Datase
 
 common := -o build/nc-timestamp-mapper -I./src/ThirdParty/ $(shared_cpp_files) src/main.cpp
 
-libs := -lstdc++fs -lnetcdf_c++4 -lsqlite3
+libs := -lstdc++fs -lnetcdf-cxx4 -lnetcdf -lsqlite3
 
 create_output_dir := mkdir -p ./build
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@
 * GCC 7.4 or newer.
 * Miniconda3 x64 (latest version) (`conda env create --file environment.yml`).
 
-## Documentation
-* Tool docs: [https://dfo-ocean-navigator.github.io/netcdf-timestamp-mapper/](https://dfo-ocean-navigator.github.io/netcdf-timestamp-mapper/)
-* Code Doxygen: [https://dfo-ocean-navigator.github.io/netcdf-timestamp-mapper/code-docs/index.html](https://dfo-ocean-navigator.github.io/netcdf-timestamp-mapper/code-docs/index.html)
-* Historical table schema: [https://dbdiagram.io/d/5dcc0404edf08a25543de03f](https://dbdiagram.io/d/5dcc0404edf08a25543de03f)
-![historical table schema](https://raw.githubusercontent.com/DFO-Ocean-Navigator/netcdf-timestamp-mapper/master/docs/img/Historical-Tables.png "Historical Table Schema")
-
 ## Building
 * Follow Dependencies above.
 * `conda activate index-tool`.
 * Clone this repo and move into the directory.
 * `git submodule update --init --recursive`
 * `make` to build the program, `make test` to build the tests, and `make clean` to...clean.
+
+
+## Documentation
+* Tool docs: [https://dfo-ocean-navigator.github.io/netcdf-timestamp-mapper/](https://dfo-ocean-navigator.github.io/netcdf-timestamp-mapper/)
+* Code Doxygen: [https://dfo-ocean-navigator.github.io/netcdf-timestamp-mapper/code-docs/index.html](https://dfo-ocean-navigator.github.io/netcdf-timestamp-mapper/code-docs/index.html)
+* Historical table schema: [https://dbdiagram.io/d/5dcc0404edf08a25543de03f](https://dbdiagram.io/d/5dcc0404edf08a25543de03f)
+![historical table schema](https://raw.githubusercontent.com/DFO-Ocean-Navigator/netcdf-timestamp-mapper/master/docs/img/Historical-Tables.png "Historical Table Schema")

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - libnetcdf=4.7.1
   - netcdf-cxx4=4.3.1
   - sqlite=3.30.1
+  - openssl


### PR DESCRIPTION
* Fixes incorrect evaluation of `CONDA_PREFIX` env var in Makefile.
* Adds `libnetcdf` to the linker.
* Renames the netcdf-cxx lib to the correct one.